### PR TITLE
Use click instead of hover for LiquidGlassButton

### DIFF
--- a/Liquid Glass for Mobile
+++ b/Liquid Glass for Mobile
@@ -72,6 +72,8 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
 
     const [isOpen, setIsOpen] = useState(false)
     const [autoTextColor, setAutoTextColor] = useState(textColor)
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    const [activeIndex, setActiveIndex] = useState<number | null>(null)
 
     useEffect(() => {
         if (!isOpen) return
@@ -92,6 +94,7 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
         } else {
             window.location.href = link
         }
+        setIsOpen(false)
     }
 
     // Calculate padding values
@@ -103,22 +106,76 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
     const items = menuItems ?? []
     const gap = itemGap ?? 8
     const menuPad = menuPadding ?? padding
+    const menuMaxWidth = Math.max(0, 320 - menuPad * 2)
     const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
     const [highlightX, setHighlightX] = useState(0)
     const [highlightW, setHighlightW] = useState(0)
+    const [highlightY, setHighlightY] = useState(0)
+    const [highlightH, setHighlightH] = useState(0)
     const itemRefs = useRef<Array<HTMLDivElement | null>>([])
     const highlightMargin = menuPad
     const highlightRadius = Math.max(0, borderRadius - highlightMargin)
     const hoverBg = "rgba(0,0,0,0.35)"
+    const indicatorIndex = hoveredIndex !== null ? hoveredIndex : activeIndex
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (
+                containerRef.current &&
+                !containerRef.current.contains(e.target as Node)
+            ) {
+                setIsOpen(false)
+            }
+        }
+        if (isOpen) document.addEventListener("click", handleClickOutside)
+        return () => document.removeEventListener("click", handleClickOutside)
+    }, [isOpen])
+
+    useEffect(() => {
+        const updateActive = () => {
+            let current: number | null = null
+            items.forEach((item, idx) => {
+                if (item.link.startsWith("#")) {
+                    const el = document.getElementById(item.link.slice(1))
+                    if (el) {
+                        const rect = el.getBoundingClientRect()
+                        if (
+                            rect.top <= window.innerHeight / 2 &&
+                            rect.bottom >= window.innerHeight / 2
+                        ) {
+                            current = idx
+                        }
+                    }
+                } else if (window.location.pathname === item.link) {
+                    current = idx
+                }
+            })
+            setActiveIndex(current)
+            if (current !== null) {
+                const el = itemRefs.current[current]
+                if (el) {
+                    setHighlightX(el.offsetLeft)
+                    setHighlightW(el.offsetWidth)
+                    setHighlightY(el.offsetTop)
+                    setHighlightH(el.offsetHeight)
+                }
+            }
+        }
+        updateActive()
+        window.addEventListener("scroll", updateActive)
+        return () => window.removeEventListener("scroll", updateActive)
+    }, [items, isOpen])
+
+    const handleButtonClick = () => {
+        setIsOpen(!isOpen)
+        if (onClick) onClick()
+    }
 
     return (
         <motion.div
             layout
-            onHoverStart={() => setIsOpen(true)}
-            onHoverEnd={() => {
-                setIsOpen(false)
-            }}
-            onClick={onClick}
+            ref={containerRef}
+            onClick={handleButtonClick}
             style={{
                 position: "relative",
                 overflow: "hidden",
@@ -127,8 +184,9 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                 width: "fit-content",
                 height:
                     isOpen && items.length > 0
-                        ? menuPad * 2 + 46
+                        ? "auto"
                         : "fit-content",
+                maxWidth: isOpen && items.length > 0 ? 320 : undefined,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
@@ -202,23 +260,6 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                     pointerEvents: "none",
                 }}
             />
-            {isOpen && hoveredIndex !== null && (
-                <motion.div
-                    style={{
-                        position: "absolute",
-                        top: highlightMargin,
-                        bottom: highlightMargin,
-                        background: "rgba(128,128,128,0.25)",
-                        backdropFilter: `blur(${blurAmount}px)`,
-                        filter: "url(#liquid-wrap-filter)",
-                        borderRadius: highlightRadius,
-                        zIndex: 1,
-                        pointerEvents: "none",
-                    }}
-                    transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                />
-            )}
-
             {isOpen && items.length > 0 ? (
                 <div
                     style={{
@@ -228,23 +269,26 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                         flexDirection: "row",
                         alignItems: "center",
                         gap,
-                        height: 46,
+                        flexWrap: "wrap",
+                        maxWidth: menuMaxWidth,
+                        minHeight: 46,
                     }}
                 >
-                    {hoveredIndex !== null && (
+                    {indicatorIndex !== null && (
                         <motion.div
                             layout
-                            initial={{ scale: 0, opacity: 0 }}
-                            animate={{ scale: 1, opacity: 1 }}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
                             style={{
                                 position: "absolute",
-                                top: 0,
+                                top: highlightY,
                                 left: highlightX,
                                 width: highlightW,
-                                height: 46,
+                                height: highlightH,
                                 borderRadius: highlightRadius,
                                 background: hoverBg,
                                 zIndex: 1,
+                                pointerEvents: "none",
                                 transformOrigin: "center",
                             }}
                             transition={{
@@ -266,10 +310,23 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                                 if (el) {
                                     setHighlightX(el.offsetLeft)
                                     setHighlightW(el.offsetWidth)
+                                    setHighlightY(el.offsetTop)
+                                    setHighlightH(el.offsetHeight)
                                 }
                                 setHoveredIndex(index)
                             }}
-                            onMouseLeave={() => setHoveredIndex(null)}
+                            onMouseLeave={() => {
+                                setHoveredIndex(null)
+                                if (activeIndex !== null) {
+                                    const el = itemRefs.current[activeIndex]
+                                    if (el) {
+                                        setHighlightX(el.offsetLeft)
+                                        setHighlightW(el.offsetWidth)
+                                        setHighlightY(el.offsetTop)
+                                        setHighlightH(el.offsetHeight)
+                                    }
+                                }
+                            }}
                             onClick={() => handleItemClick(item.link)}
                             style={{
                                 position: "relative",
@@ -290,7 +347,8 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                             <span
                                 style={{
                                     color:
-                                        hoveredIndex === index
+                                        hoveredIndex === index ||
+                                        activeIndex === index
                                             ? "#fff"
                                             : autoTextColor,
                                     ...font,


### PR DESCRIPTION
## Summary
- Toggle LiquidGlassButton menu visibility on click instead of hover
- Close menu when clicking outside the button
- Highlight menu item for current page section
- Restrict menu to 320px width and wrap items vertically when needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7cd4bb84832abd6bbaf5e9ec1b94