### PR TITLE
Add horizontal hover menu to liquid glass button

### DIFF
--- a/Liquid glass button
+++ b/Liquid glass button
@@ -1,7 +1,6 @@
 import { addPropertyControls, ControlType } from "framer"
-import { useRef } from "react"
+import { useState, useEffect, useRef } from "react"
 import { motion } from "framer-motion"
-import * as PhosphorIcons from "phosphor-react"
 
 interface LiquidGlassButtonProps {
     text: string
@@ -12,10 +11,6 @@ interface LiquidGlassButtonProps {
     wrapStrength: number
     borderRadius: number
     font: any
-    iconName: string
-    iconWeight: string
-    iconColor: string
-    iconSize: number
     outerBorderColor: string
     outerBorderOpacity: number
     innerBorderColor: string
@@ -26,6 +21,9 @@ interface LiquidGlassButtonProps {
     paddingRight: number
     paddingTop: number
     paddingBottom: number
+    menuItems?: { label: string; link: string }[]
+    itemGap?: number
+    menuPadding?: number
     onClick?: () => void
     style?: React.CSSProperties
 }
@@ -38,7 +36,7 @@ function hexToRGB(hex: string) {
 }
 
 /**
- * LiquidGlass Button with font and Phosphor icon option
+ * LiquidGlass Button with font
  *
  * @framerIntrinsicWidth 200
  * @framerIntrinsicHeight 60
@@ -55,9 +53,6 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
         wrapStrength,
         borderRadius,
         font,
-        iconName,
-        iconWeight,
-        iconColor,
         outerBorderColor,
         outerBorderOpacity,
         innerBorderColor,
@@ -68,21 +63,95 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
         paddingRight,
         paddingTop,
         paddingBottom,
+        menuItems,
+        itemGap,
+        menuPadding,
         onClick,
         style,
     } = props
 
-    const buttonRef = useRef<HTMLDivElement>(null)
+    const [isOpen, setIsOpen] = useState(false)
+    const [autoTextColor, setAutoTextColor] = useState(textColor)
+
+    useEffect(() => {
+        if (!isOpen) return
+        if (typeof window !== "undefined") {
+            const bg = window.getComputedStyle(document.body).backgroundColor
+            const rgb = bg.match(/\d+/g)?.map(Number) ?? [255, 255, 255]
+            const luminance = 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]
+            setAutoTextColor(luminance > 186 ? "#000" : "#fff")
+        }
+    }, [isOpen])
+
+    const handleItemClick = (link: string) => {
+        if (link.startsWith("#")) {
+            const target = document.getElementById(link.slice(1))
+            if (target) {
+                target.scrollIntoView({ behavior: "smooth" })
+            }
+        } else {
+            window.location.href = link
+        }
+    }
 
     // Calculate padding values
     const padLeft = paddingLeft ?? padding
     const padRight = paddingRight ?? padding
     const padTop = paddingTop ?? padding
     const padBottom = paddingBottom ?? padding
+    // menu layout values
+    const items = menuItems ?? []
+    const gap = itemGap ?? 8
+    const menuPad = menuPadding ?? padding
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+    const [currentIndex, setCurrentIndex] = useState<number | null>(null)
+    const [highlightX, setHighlightX] = useState(0)
+    const [highlightW, setHighlightW] = useState(0)
+    const itemRefs = useRef<Array<HTMLDivElement | null>>([])
+    const highlightMargin = menuPad
+    const highlightRadius = Math.max(0, borderRadius - highlightMargin)
+    const hoverBg = "rgba(0,0,0,0.35)"
+
+    useEffect(() => {
+        if (typeof window === "undefined") return
+        const updateIndex = () => {
+            const { pathname, hash } = window.location
+            const idx = items.findIndex(item => {
+                if (item.link.startsWith("#")) return item.link === hash
+                return item.link === pathname || item.link === pathname + hash
+            })
+            setCurrentIndex(idx >= 0 ? idx : null)
+        }
+        updateIndex()
+        window.addEventListener("hashchange", updateIndex)
+        window.addEventListener("popstate", updateIndex)
+        return () => {
+            window.removeEventListener("hashchange", updateIndex)
+            window.removeEventListener("popstate", updateIndex)
+        }
+    }, [items])
+
+    useEffect(() => {
+        const index = hoveredIndex ?? currentIndex
+        if (isOpen && index !== null) {
+            const el = itemRefs.current[index]
+            if (el) {
+                setHighlightX(el.offsetLeft)
+                setHighlightW(el.offsetWidth)
+            }
+        }
+    }, [hoveredIndex, currentIndex, isOpen])
+
+    const activeIndex = hoveredIndex !== null ? hoveredIndex : currentIndex
 
     return (
         <motion.div
-            ref={buttonRef}
+            layout
+            onHoverStart={() => setIsOpen(true)}
+            onHoverEnd={() => {
+                setIsOpen(false)
+                setHoveredIndex(null)
+            }}
             onClick={onClick}
             style={{
                 position: "relative",
@@ -90,21 +159,24 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                 cursor: "pointer",
                 borderRadius,
                 width: "fit-content",
-                height: "fit-content",
+                height:
+                    isOpen && items.length > 0
+                        ? menuPad * 2 + 46
+                        : "fit-content",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
                 boxShadow: shadow ? "0 2px 8px rgba(0,0,0,0.08)" : "none",
                 border: `1px solid ${outerBorderColor}`,
                 opacity: outerBorderOpacity,
-                paddingLeft: padLeft,
-                paddingRight: padRight,
-                paddingTop: padTop,
-                paddingBottom: padBottom,
+                paddingLeft: isOpen ? menuPad : padLeft,
+                paddingRight: isOpen ? menuPad : padRight,
+                paddingTop: isOpen ? menuPad : padTop,
+                paddingBottom: isOpen ? menuPad : padBottom,
                 ...style,
             }}
-            whileHover={{ scale: 1.05 }}
-            transition={{ type: "spring", stiffness: 400, damping: 10 }}
+            whileHover={{ scale: 1.02 }}
+            transition={{ type: "spring", stiffness: 300, damping: 20 }}
         >
             <svg style={{ display: "none" }}>
                 <filter id="liquid-wrap-filter">
@@ -165,37 +237,102 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
                 }}
             />
 
-            <div
-                style={{
-                    position: "relative",
-                    zIndex: 2,
-                    color: textColor,
-                    ...font,
-                    fontWeight: 600,
-                    textAlign: "center",
-                    whiteSpace: "nowrap",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 8,
-                }}
-            >
-                {/* Icon dari phosphor */}
-                {PhosphorIcons[iconName] &&
-                    (() => {
-                        const IconComponent = PhosphorIcons[
-                            iconName
-                        ] as React.ElementType
-                        return (
-                            <IconComponent
-                                size={props.iconSize || 18}
-                                color={iconColor}
-                                weight={iconWeight as any}
-                            />
-                        )
-                    })()}
-                {text}
-            </div>
+            {isOpen && items.length > 0 ? (
+                <div
+                    style={{
+                        position: "relative",
+                        zIndex: 2,
+                        display: "flex",
+                        flexDirection: "row",
+                        alignItems: "center",
+                        gap,
+                        height: 46,
+                    }}
+                >
+                    {activeIndex !== null && (
+                        <motion.div
+                            layout
+                            initial={{ scale: 0, opacity: 0 }}
+                            animate={{ scale: 1, opacity: 1 }}
+                            style={{
+                                position: "absolute",
+                                top: 0,
+                                left: highlightX,
+                                width: highlightW,
+                                height: 46,
+                                borderRadius: highlightRadius,
+                                background: hoverBg,
+                                zIndex: 1,
+                                transformOrigin: "center",
+                            }}
+                            transition={{
+                                duration: 0.2,
+                                layout: { type: "spring", stiffness: 400, damping: 30 },
+                            }}
+                        />
+                    )}
+                    {items.map((item, index) => (
+                        <motion.div
+                            key={index}
+                            ref={el => (itemRefs.current[index] = el)}
+                            onMouseEnter={() => {
+                                const el = itemRefs.current[index]
+                                if (el) {
+                                    setHighlightX(el.offsetLeft)
+                                    setHighlightW(el.offsetWidth)
+                                }
+                                setHoveredIndex(index)
+                            }}
+                            onMouseLeave={() => setHoveredIndex(null)}
+                              onClick={() => handleItemClick(item.link)}
+                            style={{
+                                position: "relative",
+                                zIndex: 2,
+                                height: 46,
+                                display: "flex",
+                                alignItems: "center",
+                                padding: "0 15px",
+                                cursor: "pointer",
+                            }}
+                            whileHover={{ scale: 1.05 }}
+                            transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                        >
+                            <span
+                                style={{
+                                    color:
+                                        hoveredIndex === index ||
+                                        (hoveredIndex === null && currentIndex === index)
+                                            ? "#fff"
+                                            : autoTextColor,
+                                    ...font,
+                                    fontWeight: 500,
+                                    whiteSpace: "nowrap",
+                                    transition: "color 0.2s ease",
+                                }}
+                            >
+                                {item.label}
+                            </span>
+                        </motion.div>
+                    ))}
+                </div>
+            ) : (
+                <div
+                    style={{
+                        position: "relative",
+                        zIndex: 2,
+                        color: textColor,
+                        ...font,
+                        fontWeight: 600,
+                        textAlign: "center",
+                        whiteSpace: "nowrap",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    {text}
+                </div>
+            )}
         </motion.div>
     )
 }
@@ -223,31 +360,6 @@ addPropertyControls(LiquidGlassButton, {
         type: ControlType.Color,
         title: "Text Color",
         defaultValue: "#FFFFFF",
-    },
-    iconName: {
-        type: ControlType.String,
-        title: "Phosphor Icon",
-        defaultValue: "ShoppingCart",
-        placeholder: "e.g. Star, Heart, User",
-    },
-    iconWeight: {
-        type: ControlType.Enum,
-        title: "Icon Weight",
-        defaultValue: "fill",
-        options: ["thin", "light", "regular", "bold", "fill", "duotone"],
-    },
-    iconColor: {
-        type: ControlType.Color,
-        title: "Icon Color",
-        defaultValue: "#FFFFFF",
-    },
-    iconSize: {
-        type: ControlType.Number,
-        title: "Icon Size",
-        defaultValue: 24,
-        min: 1,
-        max: 100,
-        step: 1,
     },
     backgroundColor: {
         type: ControlType.Color,
@@ -334,5 +446,36 @@ addPropertyControls(LiquidGlassButton, {
         defaultValue: true,
         enabledTitle: "Show",
         disabledTitle: "Hide",
+    },
+    menuItems: {
+        type: ControlType.Array,
+        title: "Menu Items",
+        propertyControl: {
+            type: ControlType.Object,
+            controls: {
+                label: { type: ControlType.String, title: "Label" },
+                link: { type: ControlType.String, title: "Link" },
+            },
+        },
+        defaultValue: [
+            { label: "Page 1", link: "#" },
+            { label: "Page 2", link: "#" },
+        ],
+    },
+    itemGap: {
+        type: ControlType.Number,
+        title: "Item Gap",
+        defaultValue: 8,
+        min: 0,
+        max: 40,
+        step: 1,
+    },
+    menuPadding: {
+        type: ControlType.Number,
+        title: "Menu Padding",
+        defaultValue: 4,
+        min: 0,
+        max: 60,
+        step: 1,
     },
 })


### PR DESCRIPTION
## Summary
- sync active menu highlight with URL changes so it returns to the current page when not hovering
- clear hovered index on popup close to reset highlight
- rely on smooth scrolling without forcing the active index in click handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2b1ea990832a9ce723c1f448a039