### PR TITLE
feat: track menu item visibility

### DIFF
--- a/Liquid glass button
+++ b/Liquid glass button
@@ -108,9 +108,19 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
     const [highlightX, setHighlightX] = useState(0)
     const [highlightW, setHighlightW] = useState(0)
     const itemRefs = useRef<Array<HTMLDivElement | null>>([])
+    const sectionRefs = useRef<Array<HTMLElement | null>>([])
     const highlightMargin = menuPad
     const highlightRadius = Math.max(0, borderRadius - highlightMargin)
     const hoverBg = "rgba(0,0,0,0.35)"
+
+    useEffect(() => {
+        if (typeof document === "undefined") return
+        sectionRefs.current = items.map(item =>
+            item.link.startsWith("#")
+                ? document.getElementById(item.link.slice(1))
+                : null
+        )
+    }, [items])
     
     useEffect(() => {
         if (typeof window === "undefined") return
@@ -129,6 +139,26 @@ export default function LiquidGlassButton(props: LiquidGlassButtonProps) {
             window.removeEventListener("hashchange", updateIndex)
             window.removeEventListener("popstate", updateIndex)
         }
+    }, [items])
+
+    useEffect(() => {
+        if (typeof window === "undefined") return
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const idx = sectionRefs.current.indexOf(
+                        entry.target as HTMLElement
+                    )
+                    if (idx !== -1) {
+                        setCurrentIndex(idx)
+                    }
+                }
+            })
+        })
+        sectionRefs.current.forEach(el => {
+            if (el) observer.observe(el)
+        })
+        return () => observer.disconnect()
     }, [items])
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Map menu item links to DOM nodes
- Observe section visibility and update current index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99facfe0832abffc652dd3927117